### PR TITLE
Modify qscore simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,12 @@ python simulator.py --mode=read
 		    --del_epoch_list 0 1 2 3 4 5 6 7 8 9
 
 python simulator.py --mode=qscore_fastq
-		    --qscore_simulation_folder=pre-trained_parameters
-		    --qscore_simulation_fname=errorness
-		    --qscore_epoch_list 0
+		    --qscore_simulation_errorfree_folder=pre-trained_parameters
+		    --qscore_simulation_errorfree_fname=errorfree
+		    --qscore_errorfree_epoch_list 0
+		    --qscore_simulation_errorness_folder=pre-trained_parameters
+		    --qscore_simulation_errorness_fname=errorness
+		    --qscore_errorness_epoch_list 0
 		    --simulation_fname=results/simulations/simulated.data
 ```
 

--- a/seq_simul/simulator/seq_simulator.py
+++ b/seq_simul/simulator/seq_simulator.py
@@ -326,26 +326,43 @@ def seq_simulator_qscore(opt, errorfree_filename, errorness_filename):
     """
     split_data_based_on_ed(opt.simulation_fname, errorfree_filename, errorness_filename)
     output_filename = opt.simulated_result_fname
+    len_oligo = opt.oligo_len
+    padding_s = opt.padding_num
 
-    opt.simulation_fname = errorfree_filename
-    opt.qscore_simulation_folder = opt.qscore_simulation_errorfree_folder
-    opt.qscore_simulation_fname = opt.qscore_simulation_errorfree_fname
-    opt.qscore_epoch_list = opt.qscore_errorfree_epoch_list
-    opt.simulated_result_fname = 'errorfree'
-    seq_simulator(opt)
+    # The errorfree case
+    if os.path.getsize(errorfree_filename):
+        opt.simulation_fname = errorfree_filename
+        opt.qscore_simulation_folder = opt.qscore_simulation_errorfree_folder
+        opt.qscore_simulation_fname = opt.qscore_simulation_errorfree_fname
+        opt.qscore_epoch_list = opt.qscore_errorfree_epoch_list
+        opt.simulated_result_fname = 'error-free'
+        opt.oligo_len = len_oligo
+        opt.padding_num = padding_s
+        seq_simulator(opt)
+        os.remove(errorfree_filename)
+    else:
+        print('No error free data file')
 
-    opt.simulation_fname = errorness_filename
-    opt.qscore_simulation_folder = opt.qscore_simulation_errorness_folder
-    opt.qscore_simulation_fname = opt.qscore_simulation_errorness_fname
-    opt.qscore_epoch_list = opt.qscore_errorness_epoch_list
-    opt.simulated_result_fname = 'errorness'
-    seq_simulator(opt)
+    # The errorness case
+    if os.path.getsize(errorness_filename):
+        opt.simulation_fname = errorness_filename
+        opt.qscore_simulation_folder = opt.qscore_simulation_errorness_folder
+        opt.qscore_simulation_fname = opt.qscore_simulation_errorness_fname
+        opt.qscore_epoch_list = opt.qscore_errorness_epoch_list
+        opt.simulated_result_fname = 'error-ness'
+        opt.oligo_len = len_oligo
+        opt.padding_num = padding_s
+        seq_simulator(opt)
+        os.remove(errorness_filename)
+    else:
+        print('No error ness data file')
 
+    # Merge the files to one
     if opt.mode == 'qscore_data':
         file_type = '.data'
     elif opt.mode == 'qscore_fastq':
         file_type = '.fastq'
-    errorfree_output = opt.simulated_result_path + 'errorfree' + file_type
-    errorness_output = opt.simulated_result_path + 'errorness' + file_type
+    errorfree_output = opt.simulated_result_path + 'error-free' + file_type
+    errorness_output = opt.simulated_result_path + 'error-ness' + file_type
     output_filename = opt.simulated_result_path + output_filename + file_type
     merge_simulated_data_to_one(errorfree_output, errorness_output, output_filename)

--- a/seq_simul/simulator/seq_simulator.py
+++ b/seq_simul/simulator/seq_simulator.py
@@ -339,9 +339,9 @@ def seq_simulator_qscore(opt, errorfree_filename, errorness_filename):
         opt.oligo_len = len_oligo
         opt.padding_num = padding_s
         seq_simulator(opt)
-        os.remove(errorfree_filename)
     else:
         print('No error free data file')
+    os.remove(errorfree_filename)
 
     # The errorness case
     if os.path.getsize(errorness_filename):
@@ -353,9 +353,9 @@ def seq_simulator_qscore(opt, errorfree_filename, errorness_filename):
         opt.oligo_len = len_oligo
         opt.padding_num = padding_s
         seq_simulator(opt)
-        os.remove(errorness_filename)
     else:
         print('No error ness data file')
+    os.remove(errorness_filename)
 
     # Merge the files to one
     if opt.mode == 'qscore_data':

--- a/seq_simul/simulator/seq_simulator.py
+++ b/seq_simul/simulator/seq_simulator.py
@@ -9,7 +9,8 @@ from seq_simul.utils.convert import (convert_onehot_to_read, concat_seq,
                                      convert_seqs_to_onehot, get_list_seq)
 from seq_simul.utils.miscs import get_device
 from seq_simul.simulator.simulator_util import (load_simulator_input, get_read_simulator,
-                                                get_qscore_simulator, record_result, split_data_based_on_ed)
+                                                get_qscore_simulator, record_result,
+                                                split_data_based_on_ed, merge_simulated_data_to_one)
 
 
 def read_simulator(oligos, picked_G, G_ins, G_sub, G_del, ins_opt, sub_opt, del_opt, device):
@@ -324,15 +325,27 @@ def seq_simulator_qscore(opt, errorfree_filename, errorness_filename):
                 the error-ness data file name (edit distance is not 0)
     """
     split_data_based_on_ed(opt.simulation_fname, errorfree_filename, errorness_filename)
+    output_filename = opt.simulated_result_fname
 
     opt.simulation_fname = errorfree_filename
     opt.qscore_simulation_folder = opt.qscore_simulation_errorfree_folder
     opt.qscore_simulation_fname = opt.qscore_simulation_errorfree_fname
     opt.qscore_epoch_list = opt.qscore_errorfree_epoch_list
+    opt.simulated_result_fname = 'errorfree'
     seq_simulator(opt)
 
     opt.simulation_fname = errorness_filename
     opt.qscore_simulation_folder = opt.qscore_simulation_errorness_folder
     opt.qscore_simulation_fname = opt.qscore_simulation_errorness_fname
     opt.qscore_epoch_list = opt.qscore_errorness_epoch_list
+    opt.simulated_result_fname = 'errorness'
     seq_simulator(opt)
+
+    if opt.mode == 'qscore_data':
+        file_type = '.data'
+    elif opt.mode == 'qscore_fastq':
+        file_type = '.fastq'
+    errorfree_output = opt.simulated_result_path + 'errorfree' + file_type
+    errorness_output = opt.simulated_result_path + 'errorness' + file_type
+    output_filename = opt.simulated_result_path + output_filename + file_type
+    merge_simulated_data_to_one(errorfree_output, errorness_output, output_filename)

--- a/seq_simul/simulator/seq_simulator.py
+++ b/seq_simul/simulator/seq_simulator.py
@@ -9,7 +9,7 @@ from seq_simul.utils.convert import (convert_onehot_to_read, concat_seq,
                                      convert_seqs_to_onehot, get_list_seq)
 from seq_simul.utils.miscs import get_device
 from seq_simul.simulator.simulator_util import (load_simulator_input, get_read_simulator,
-                                                get_qscore_simulator, record_result)
+                                                get_qscore_simulator, record_result, split_data_based_on_ed)
 
 
 def read_simulator(oligos, picked_G, G_ins, G_sub, G_del, ins_opt, sub_opt, del_opt, device):
@@ -310,3 +310,29 @@ def seq_simulator(opt):
                                                                            qscore_opt, G_qs, device)
 
         index = record_result(opt, result_oligos, result_reads, result_qscores, index)
+
+
+def seq_simulator_qscore(opt, errorfree_filename, errorness_filename):
+    """
+        The flow of the qscore sequence simulator
+        INPUT:
+            opt (:obj:`Namespace`):
+                the set of parameters
+            errorfree_filename (:str:filename):
+                the error-free data file name (edit distance is 0)
+            errorness_filename (:str:filename):
+                the error-ness data file name (edit distance is not 0)
+    """
+    split_data_based_on_ed(opt.simulation_fname, errorfree_filename, errorness_filename)
+
+    opt.simulation_fname = errorfree_filename
+    opt.qscore_simulation_folder = opt.qscore_simulation_errorfree_folder
+    opt.qscore_simulation_fname = opt.qscore_simulation_errorfree_fname
+    opt.qscore_epoch_list = opt.qscore_errorfree_epoch_list
+    seq_simulator(opt)
+
+    opt.simulation_fname = errorness_filename
+    opt.qscore_simulation_folder = opt.qscore_simulation_errorness_folder
+    opt.qscore_simulation_fname = opt.qscore_simulation_errorness_fname
+    opt.qscore_epoch_list = opt.qscore_errorness_epoch_list
+    seq_simulator(opt)

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -140,3 +140,57 @@ def record_result(opt, oligo, read, qscore, index):
         logging.debug(simul_data_msg)
 
     return index + opt.simulation_batch_num
+
+
+def split_data_based_on_ed(original_filename, errorfree_filename, errorness_filename):
+    """
+    Because the qscore simulator is divided into two modes:
+        errorfree and errorness
+    according to the edit distance,
+    the data should be split according to the edit distance.
+    INPUT:
+        original_filename (:str:filename):
+            the input data file name
+        errorfree_filename (:str:filename):
+            the error-free data file name (edit distance is 0)
+        errorness_filename (:str:filename):
+            the error-ness data file name (edit distance is not 0)
+
+    OUTPUT:
+        Two files
+    """
+    if not original_filename.endswith('.data'):
+        raise ValueError("qscore simulator needs two sequences, please check data file.")
+
+    with open(f'{original_filename}', 'r') as f_in:
+        with open(f'{errorfree_filename}', 'w') as f_errorfree,\
+                open(f'{errorness_filename}', 'w') as f_errorness:
+            for idx, line in enumerate(f_in):
+                if idx % 5 == 0:
+                    read = line
+                elif idx % 5 == 1:
+                    qscore = line
+                elif idx % 5 == 2:
+                    oligo = line
+                elif idx % 5 == 3:
+                    ed = int(line.rstrip('\n'))
+                elif idx % 5 == 4:
+                    index = line
+
+                    if ed == 0:
+                        f_errorfree.write(read)
+                        f_errorfree.write(qscore)
+                        f_errorfree.write(oligo)
+                        f_errorfree.write(f'{ed}\n')
+                        f_errorfree.write(index)
+                    else:
+                        f_errorness.write(read)
+                        f_errorness.write(qscore)
+                        f_errorness.write(oligo)
+                        f_errorness.write(f'{ed}\n')
+                        f_errorness.write(index)
+
+                if not line:
+                    break
+
+    print('Splitting data based on edit distance is done')

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -129,7 +129,7 @@ def record_result(opt, oligo, read, qscore, index):
             simul_data_msg = f'{i+index}\n' \
                              f'{final_read}\n' \
                              f'+\n' \
-                             f'{final_qscore}'\
+                             f'{final_qscore}\n'\
                              f'{final_oligo}'
         elif opt.mode == 'qscore_fastq':
             simul_data_msg = f'{i+index}\n' \

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -167,26 +167,26 @@ def split_data_based_on_ed(original_filename, errorfree_filename, errorness_file
                 open(f'{errorness_filename}', 'w') as f_errorness:
             for idx, line in enumerate(f_in):
                 if idx % 5 == 0:
-                    read = line
+                    read = line.rstrip('\n')
                 elif idx % 5 == 1:
                     qscore = line
                 elif idx % 5 == 2:
-                    oligo = line
+                    oligo = line.rstrip('\n')
                 elif idx % 5 == 3:
-                    ed = int(line.rstrip('\n'))
+                    ed = v_lev_dist(oligo, read)
                 elif idx % 5 == 4:
                     index = line
 
                     if ed == 0:
-                        f_errorfree.write(read)
+                        f_errorfree.write(f'{read}\n')
                         f_errorfree.write(qscore)
-                        f_errorfree.write(oligo)
+                        f_errorfree.write(f'{oligo}\n')
                         f_errorfree.write(f'{ed}\n')
                         f_errorfree.write(index)
                     else:
-                        f_errorness.write(read)
+                        f_errorness.write(f'{read}\n')
                         f_errorness.write(qscore)
-                        f_errorness.write(oligo)
+                        f_errorness.write(f'{oligo}\n')
                         f_errorness.write(f'{ed}\n')
                         f_errorness.write(index)
 

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -194,3 +194,28 @@ def split_data_based_on_ed(original_filename, errorfree_filename, errorness_file
                     break
 
     print('Splitting data based on edit distance is done')
+
+
+def merge_simulated_data_to_one(errorfree_filename, errorness_filename, output_filename):
+    """
+    Merge the errorfree and errorness files to one output fil
+    according to the edit distance,
+    the data should be split according to the edit distance.
+    INPUT:
+        errorfree_filename (:str:filename):
+            the error-free data file name (edit distance is 0)
+        errorness_filename (:str:filename):
+            the error-ness data file name (edit distance is not 0)
+        output_filename (:str:filename):
+            the output data file name
+    OUTPUT:
+        One file
+    """
+    with open(errorfree_filename, 'r') as f1, open(errorness_filename, 'r') as f2:
+        with open(output_filename, 'w') as f_out:
+            _error_free_ = f1.read()
+            f_out.write(_error_free_)
+            _error_ness_ = f2.read()
+            f_out.write(_error_ness_)
+
+    print('Merge data completed')

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -203,7 +203,7 @@ def split_data_based_on_ed(original_filename, errorfree_filename, errorness_file
 
 def merge_simulated_data_to_one(errorfree_filename, errorness_filename, output_filename):
     """
-    Merge the errorfree and errorness files to one output fil
+    Merge the errorfree and errorness files to one output file
     according to the edit distance,
     the data should be split according to the edit distance.
     INPUT:

--- a/seq_simul/simulator/simulator_util.py
+++ b/seq_simul/simulator/simulator_util.py
@@ -162,6 +162,11 @@ def split_data_based_on_ed(original_filename, errorfree_filename, errorness_file
     if not original_filename.endswith('.data'):
         raise ValueError("qscore simulator needs two sequences, please check data file.")
 
+    # Check the input data size
+    if not os.path.getsize(original_filename):
+        raise ValueError("The input data is empty. Please check the input data.")
+
+    # Split data according to edit distance
     with open(f'{original_filename}', 'r') as f_in:
         with open(f'{errorfree_filename}', 'w') as f_errorfree,\
                 open(f'{errorness_filename}', 'w') as f_errorness:
@@ -211,11 +216,20 @@ def merge_simulated_data_to_one(errorfree_filename, errorness_filename, output_f
     OUTPUT:
         One file
     """
-    with open(errorfree_filename, 'r') as f1, open(errorness_filename, 'r') as f2:
-        with open(output_filename, 'w') as f_out:
-            _error_free_ = f1.read()
-            f_out.write(_error_free_)
-            _error_ness_ = f2.read()
-            f_out.write(_error_ness_)
+    if not os.path.exists(errorfree_filename):
+        os.rename(errorness_filename, output_filename)
+    elif not os.path.exists(errorness_filename):
+        os.rename(errorfree_filename, output_filename)
+    else:
+        with open(errorfree_filename, 'r') as f1, open(errorness_filename, 'r') as f2:
+            with open(output_filename, 'w') as f_out:
+                _error_free_ = f1.read()
+                f_out.write(_error_free_)
+                _error_ness_ = f2.read()
+                f_out.write(_error_ness_)
+
+        # Remove unnecessary data files
+        os.remove(errorfree_filename)
+        os.remove(errorness_filename)
 
     print('Merge data completed')

--- a/simulator.py
+++ b/simulator.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from seq_simul.simulator.seq_simulator import seq_simulator
+from seq_simul.simulator.seq_simulator import seq_simulator, seq_simulator_qscore
 
 
 if __name__ == "__main__":
@@ -10,8 +10,6 @@ if __name__ == "__main__":
     parser.add_argument("--error_proportion_file", type=str,
                         default="seq_simul/data/test_error_proportion.log",
                         help="path of the error proportion log file")
-    parser.add_argument("--read_data", type=str, default='read',
-                        help="data to read (read|qscore)")
     parser.add_argument("--mode", type=str, default='read',
                         help="qscore_data: qscore only, input data is .data, saved in .data format\
                               qscore_fastq: qscore only, input data is .data, saved in fastq format\
@@ -23,7 +21,7 @@ if __name__ == "__main__":
     parser.add_argument("--simulation_fname", type=str,
                         default="seq_simul/data/test_oligo.txt",
                         help="if mode=all|read, input data is oligo(.txt)\
-                              if mode=qscore, input datais .data file")
+                              if mode=qscore, input data is .data file")
     parser.add_argument("--simulated_result_path", type=str, default="results/simulations/",
                         help="location of simulation folder path")
     parser.add_argument("--simulated_result_fname", type=str, default="simulated",
@@ -72,6 +70,22 @@ if __name__ == "__main__":
                         help="range of epoch to randomize for qscore simulation")
     parser.add_argument("--qscore_epoch_list", nargs='+', default=[0, 1],
                         help="list of epoch for qscore simulation")
+    parser.add_argument("--qscore_simulation_errorfree_folder", type=str,
+                        default="seq_simul/simulator/tests",
+                        help="path of the pth folder for qscore simulation errorfree situation")
+    parser.add_argument("--qscore_simulation_errorfree_fname", type=str,
+                        default='trained_qscore_G',
+                        help="range of epoch to randomize for qscore simulation errorfree situation")
+    parser.add_argument("--qscore_errorfree_epoch_list", nargs='+', default=[0, 1],
+                        help="list of epoch for qscore simulation errorfree situation")
+    parser.add_argument("--qscore_simulation_errorness_folder", type=str,
+                        default="seq_simul/simulator/tests",
+                        help="path of the pth folder for qscore simulation errorness situation")
+    parser.add_argument("--qscore_simulation_errorness_fname", type=str,
+                        default='trained_qscore_G',
+                        help="range of epoch to randomize for qscore simulation errorness situation")
+    parser.add_argument("--qscore_errorness_epoch_list", nargs='+', default=[0, 1],
+                        help="list of epoch for qscore simulation errorness situation")
 
     # Fixed options from json file
     parser.add_argument("--oligo_len", type=int, default=145,
@@ -115,11 +129,14 @@ if __name__ == "__main__":
 
     os.makedirs(simulator_opt.simulated_result_path, exist_ok=True)
 
-    seq_simulator(simulator_opt)
     if simulator_opt.mode == "read":
+        seq_simulator(simulator_opt)
         print("Read-sequence Simulation Complete")
 
     elif simulator_opt.mode in ('qscore_data', 'qscore_fastq'):
+        filename_errorfree = simulator_opt.simulated_result_path + 'errorfree.data'
+        filename_errorness = simulator_opt.simulated_result_path + 'errorness.data'
+        seq_simulator_qscore(simulator_opt, filename_errorfree, filename_errorness)
         print("Quality-score Simulation Complete")
 
     else:

--- a/simulator.py
+++ b/simulator.py
@@ -10,6 +10,8 @@ if __name__ == "__main__":
     parser.add_argument("--error_proportion_file", type=str,
                         default="seq_simul/data/test_error_proportion.log",
                         help="path of the error proportion log file")
+    parser.add_argument("--read_data", type=str, default='read',
+                        help="data to read (read|qscore)")
     parser.add_argument("--mode", type=str, default='read',
                         help="qscore_data: qscore only, input data is .data, saved in .data format\
                               qscore_fastq: qscore only, input data is .data, saved in fastq format\


### PR DESCRIPTION
Modify qscore simulator
1. For errorfree and errorness cases, split the data according to edit distance before running seq_simul
2. Add options for two cases
3. Modify the readme document
4. Modify the code for bugs